### PR TITLE
adds alias /score/ to /scores/

### DIFF
--- a/src/pages/score/[id].vue
+++ b/src/pages/score/[id].vue
@@ -8,6 +8,10 @@ const id = route.params.id
 const app$ = useNuxtApp()
 const data = await app$.$client.score.id.query({ id })
 
+definePageMeta({
+  alias: ['/scores/:id'],
+})
+
 useHead({
 
   title() {


### PR DESCRIPTION
Changes

- Added alias to match the osu! request route.
- Ensured compatibility with all services that use osu! servers.

Examples
Before:

Old link format: https://osu.ppy.sb/score/78543
After:

Added redirect: https://osu.ppy.sb/scores/2843369360 to https://osu.ppy.sb/score/78543