### PR TITLE
feat(i18n): complete French (fr-FR) translations

### DIFF
--- a/src/components/app/dan/cond.vue
+++ b/src/components/app/dan/cond.vue
@@ -181,6 +181,56 @@ const { t, te } = useI18n({
         },
       },
     },
+    'fr-FR': {
+      dan: {
+        requirement: {
+          [Requirement.Pass]: 'Pass',
+          [Requirement.NoPause]: 'Sans Pause',
+        },
+        cond: {
+          [OP.AccGte]: 'Précision ≥',
+          [OP.ScoreGte]: 'Score ≥',
+          [OP.ModeEq]: 'Mode =',
+          [OP.RulesetEq]: 'Règle =',
+          [OP.BanchoBeatmapIdEq]: 'Bancho bid =',
+          [OP.BeatmapMd5Eq]: 'Beatmap MD5 =',
+          [OP.StableModIncludeAny]: 'Au moins un mod',
+          [OP.StableModIncludeAll]: 'Tous les mods',
+          [OP.Extends]: 'Remplit les conditions de',
+          [OP.OR]: 'ou',
+          [OP.AND]: 'et',
+          [OP.NOT]: 'non',
+          [OP.Remark]: 'Remarque',
+          [OP.NoPause]: 'Sans Pause',
+          [OP.Expect]: 'Doit',
+        },
+        cmp: {
+          [CompareOP.Gt]: '>',
+          [CompareOP.Gte]: '≥',
+          [CompareOP.Lt]: '<',
+          [CompareOP.Lte]: '≤',
+          [CompareOP.Eq]: '=',
+          [CompareOP.Ne]: '≠',
+        },
+        key: {
+          mode: '@:global.mode',
+          ruleset: '@:global.ruleset',
+          accuracy: '@:global.accuracy',
+          maxCombo: '@:global.max-combo',
+          score: 'Score',
+          count: {
+            miss: 'Miss',
+            50: '50',
+            100: '100',
+            300: '300',
+            geki: 'Geki',
+            katu: 'Katu',
+            200: '200',
+            max: 'Max',
+          },
+        },
+      },
+    },
   } satisfies Record<string, Translation>,
 })
 
@@ -246,6 +296,12 @@ zh-CN:
   delete: 删除
   select: 选择
   add: 添加
+
+fr-FR:
+  reset: Réinitialiser
+  delete: Supprimer
+  select: Sélectionner
+  add: Ajouter
 </i18n>
 
 <template>

--- a/src/components/app/dan/explain-cond.vue
+++ b/src/components/app/dan/explain-cond.vue
@@ -127,6 +127,52 @@ const messages = Object.freeze({
       },
     },
   },
+  'fr-FR': {
+    dan: {
+      cond: {
+        [OP.AccGte]: 'Précision ≥ {val}',
+        [OP.ScoreGte]: 'Score ≥ {val}',
+        [OP.ModeEq]: 'Mode = {val}',
+        [OP.RulesetEq]: 'Règle = {val}',
+        [OP.BanchoBeatmapIdEq]: 'ID de la beatmap = {val} sur Bancho',
+        [OP.BeatmapMd5Eq]: 'MD5 de la beatmap = {val}',
+        [OP.StableModIncludeAny]: 'Joué avec au moins un mod parmi {val}',
+        [OP.StableModIncludeAll]: 'Joué avec les mods {val}',
+        [OP.Extends]: 'Remplit toutes les conditions de {val}',
+        [OP.OR]: 'Ou',
+        [OP.AND]: 'Et',
+        [OP.NOT]: 'Non',
+        [OP.Remark]: 'Remarque : {remark} {val}',
+        [OP.NoPause]: 'Sans Pause',
+        [OP.Expect]: 'Doit',
+      },
+      cmp: {
+        [CompareOP.Gt]: '>',
+        [CompareOP.Gte]: '≥',
+        [CompareOP.Lt]: '<',
+        [CompareOP.Lte]: '≤',
+        [CompareOP.Eq]: '=',
+        [CompareOP.Ne]: '≠',
+      },
+      key: {
+        mode: '@:global.mode',
+        ruleset: '@:global.ruleset',
+        accuracy: '@:global.accuracy',
+        maxCombo: '@:global.max-combo',
+        score: 'Score',
+        count: {
+          miss: 'Miss',
+          50: '50',
+          100: '100',
+          300: '300',
+          geki: 'Geki',
+          katu: 'Katu',
+          200: '200',
+          max: 'Max',
+        },
+      },
+    },
+  },
 
 } satisfies Record<string, Loc>)
 

--- a/src/components/dan/course/course-delete-confirm.vue
+++ b/src/components/dan/course/course-delete-confirm.vue
@@ -29,7 +29,11 @@ zh-CN:
   delete-dans: 删除池中的段位
   cancel: 取消
 
-  # TODO fr, DE
+fr-FR:
+  delete: Supprimer
+  confirm-delete: Voulez-vous vraiment supprimer ce cours ?
+  delete-dans: Supprimer les dans du cours
+  cancel: Annuler
   </i18n>
 
 <template>

--- a/src/components/dan/course/course-form-header.vue
+++ b/src/components/dan/course/course-form-header.vue
@@ -117,4 +117,12 @@ zh-CN:
   creator: 创建者
   updated-at: 更新时间
   updater: 更新者
+
+fr-FR:
+  name: Nom
+  description: Description
+  created-at: Créé le
+  creator: Créateur
+  updated-at: Mis à jour le
+  updater: Éditeur
 </i18n>

--- a/src/components/dan/explain-requirement.vue
+++ b/src/components/dan/explain-requirement.vue
@@ -18,6 +18,9 @@ en-GB:
 
 zh-CN:
   requirement: '判定: '
+
+fr-FR:
+  requirement: 'Condition : '
 </i18n>
 
 <template>

--- a/src/components/userpage/recent-scores.vue
+++ b/src/components/userpage/recent-scores.vue
@@ -74,7 +74,10 @@ zh-CN:
   recent: 最近成绩
   folded: '{i} 个折叠的成绩'
 
-# TODO FR
+fr-FR:
+  recent: Scores récents
+  folded: '{i} scores repliés'
+
 # TODO DE
 </i18n>
 

--- a/src/locales/base/fr-FR.ts
+++ b/src/locales/base/fr-FR.ts
@@ -1,15 +1,32 @@
 import type { GlobalI18n } from '../@types'
+import { Requirement } from '../../def/dan'
+import { RankingStatus } from '~/def/beatmap'
 import { CountryCode } from '~/def/country-code'
-import { Rank } from '~/def'
+import { Mode, Rank, Ruleset } from '~/def'
+import { Mail } from '~/def/mail'
+import { GucchoError } from '~/def/messages'
 import { Scope, UserRole } from '~/def/user'
 
 export default {
-  // reuse en-GB
-  server: {} as any,
-  footer: {} as any,
+  server: {
+    name: 'Guccho',
+  },
+  footer: {
+    about: 'À propos',
+    resources: 'Ressources',
+  },
 
-  mode: {} as any,
-  ruleset: {} as any,
+  mode: {
+    [Mode.Osu]: 'Osu',
+    [Mode.Taiko]: 'Taiko',
+    [Mode.Fruits]: 'CTB',
+    [Mode.Mania]: 'Mania',
+  },
+  ruleset: {
+    [Ruleset.Standard]: 'Standard',
+    [Ruleset.Relax]: 'Relax',
+    [Ruleset.Autopilot]: 'Autopilot',
+  },
   rank: {
     [Rank.PPv2]: 'Performance(v2)',
     [Rank.PPv1]: 'Performance(v1)',
@@ -27,9 +44,16 @@ export default {
     'logs': 'Logs',
     'articles': 'Articles',
     'clans': 'Clans',
-    'user-management': 'Gestion d\'utilisateur',
-    // TODO refine fr translation
-    'account-recovery': 'Account Recovery',
+    'user-management': 'Gestion des utilisateurs',
+    'account-recovery': 'Récupération de compte',
+    'dan': {
+      'dan': 'Dan',
+      'dans': 'Dans',
+      'courses': 'Cours',
+      'compose': 'Composer',
+      'manage': 'Gérer le cours',
+      'create-course': 'Créer un cours',
+    },
   },
 
   global: {
@@ -40,19 +64,18 @@ export default {
     'player': 'Joueur',
     'rank': 'Rang',
     'mods': 'Mods',
-    'played-at': 'Temps de jeu',
+    'played-at': 'Joué le',
     'acc': 'Acc',
     'accuracy': 'Précision',
     'play-count': 'Nombre de parties',
     'beatmapsets': 'Beatmapsets',
     'beatmaps': 'Beatmaps',
-    'users': 'Utilisateur',
+    'users': 'Utilisateurs',
     'session': 'Session',
     'password': 'Mot de passe',
-    // TODO refine fr translation
     'email': 'Email',
-    'otp': 'One time code',
-    'verify': 'Verify',
+    'otp': 'Code à usage unique',
+    'verify': 'Vérifier',
     'wip': 'WIP',
     'max-combo': 'Max combo',
   },
@@ -86,9 +109,72 @@ export default {
     sessions: 'Connexion Web',
   },
 
-  beatmap: {} as any,
+  beatmap: {
+    status: {
+      [RankingStatus.Graveyard]: 'Cimetière',
+      [RankingStatus.WIP]: 'WIP',
+      [RankingStatus.Pending]: 'En attente',
+      [RankingStatus.Ranked]: 'Classée',
+      [RankingStatus.Approved]: 'Approuvée',
+      [RankingStatus.Qualified]: 'Qualifiée',
+      // official osu! uses "Loved" untranslated
+      [RankingStatus.Loved]: 'Loved',
+      [RankingStatus.Deleted]: 'Supprimée',
+      [RankingStatus.NotFound]: 'Introuvable',
+      [RankingStatus.Unknown]: 'Inconnue',
+    },
+  },
 
-  error: {} as any,
+  error: {
+    [GucchoError.UnknownError]: 'Une erreur inconnue est survenue.',
+    [GucchoError.UserNotFound]: 'Utilisateur introuvable.',
+    [GucchoError.UserExists]: 'Cet utilisateur existe déjà.',
+    [GucchoError.ConflictEmail]: 'Cette adresse email est déjà utilisée.',
+    [GucchoError.IncorrectPassword]: 'Mot de passe incorrect.',
+    [GucchoError.PasswordNotMatch]: 'Les mots de passe ne correspondent pas.',
+    [GucchoError.OldPasswordMismatch]: 'L\'ancien mot de passe fourni est incorrect.',
+    [GucchoError.RelationNotFound]: 'Relation introuvable.',
+    [GucchoError.AtLeastOneUserNotExists]: 'Au moins un utilisateur n\'existe pas.',
+    [GucchoError.UnableToRetrieveSession]: 'Impossible de récupérer la session.',
+    [GucchoError.UnableToRefreshSession]: 'Impossible de mettre à jour votre session.',
+    [GucchoError.YouNeedToLogin]: 'Vous devez vous connecter.',
+    [GucchoError.SessionNotFound]: 'Session introuvable.',
+    [GucchoError.UpdateUserSettingsFailed]: 'Échec de la mise à jour des paramètres utilisateur.',
+    [GucchoError.ConflictRelation]: 'Vous avez déjà une relation avec ce joueur.',
+    [GucchoError.MissingServerAvatarConfig]: 'Le serveur est mal configuré : l\'emplacement des avatars est manquant.',
+    [GucchoError.ModeNotSupported]: 'Mode non pris en charge.',
+    [GucchoError.ModeOrRulesetNotSupported]: 'Mode ou ruleset non pris en charge.',
+    [GucchoError.UpdateUserpageFailed]: 'Échec de la mise à jour de la page utilisateur.',
+    [GucchoError.MimeNotImage]: 'Le fichier fourni n\'est pas une image.',
+    [GucchoError.HackerTryingToDeleteAllAvatars]: 'QUELQU\'UN ESSAIE DE SUPPRIMER TOUS LES AVATARS.',
+    [GucchoError.DeletingMoreThanOneAvatars]: 'Tentative de suppression de plus de 2 fichiers. Veuillez contacter le support.',
+    [GucchoError.RequireAdminPrivilege]: 'Nécessite un rôle du staff.',
+    [GucchoError.EmailTokenNotFound]: 'Le jeton de vérification de l\'email a expiré.',
+    [GucchoError.InvalidId]: 'ID invalide',
+    [GucchoError.BeatmapNotFound]: 'Beatmap introuvable.',
+    [GucchoError.EmptyPassword]: 'Le mot de passe ne peut pas être vide.',
+    [GucchoError.ProhibitedRelationWithSelf]: 'Vous ne pouvez pas avoir de relation avec vous-même.',
+    [GucchoError.RegistrationFailed]: 'Échec de l\'inscription.',
+    [GucchoError.ScoreNotFound]: 'Score introuvable.',
+    [GucchoError.UnableToUpdateSession]: 'Impossible de mettre à jour la session.',
+    [GucchoError.ClanNotFound]: 'Clan introuvable.',
+    [GucchoError.AssertionError]: 'Erreur d\'assertion : cet état ne devrait jamais se produire !',
+    [GucchoError.InsufficientPrivilegeToEditArticle]: 'Vous n\'avez pas les privilèges pour modifier cet article.',
+    [GucchoError.FileSystemArticlePathOutsideArticleRoot]: 'Le chemin d\'enregistrement est en dehors du dossier des articles.',
+    [GucchoError.TryingToDeleteFallbackContents]: 'Tentative de suppression du contenu de secours.',
+    [GucchoError.ArticleNotFound]: 'Article introuvable.',
+    [GucchoError.FeatureNotSupported]: 'Cette fonctionnalité n\'est pas prise en charge.',
+    [GucchoError.DanNotFound]: 'Dan introuvable.',
+    [GucchoError.CannotSaveDan]: 'Impossible d\'enregistrer le Dan',
+    [GucchoError.DanCourseNotFound]: 'Cours de Dan introuvable.',
+    [GucchoError.CannotSaveDanCourse]: 'Impossible d\'enregistrer le cours de Dan',
+  },
+  dan: {
+    requirement: {
+      [Requirement.Pass]: 'Pass',
+      [Requirement.NoPause]: 'Sans Pause',
+    },
+  },
   country: {
     [CountryCode.Unknown]: 'Inconnu',
     [CountryCode.Afghanistan]: 'Afghanistan',
@@ -341,5 +427,50 @@ export default {
     [CountryCode.Zambia]: 'Zambie',
     [CountryCode.Zimbabwe]: 'Zimbabwe',
   },
-  mail: {} as any,
+  mail: {
+    [Mail.Variant.Registration]: {
+      subject: '{serverName} - Inscription',
+      content: `
+Bonjour,
+
+Pour vérifier votre adresse email pour {serverName}, veuillez cliquer sur le lien suivant :
+{link}
+
+Vous pouvez également utiliser le code suivant : {otp}
+
+Ce lien et ce code sont valables {ttl} minutes.
+N'hésitez pas à nous contacter pour toute question.
+
+{serverName}
+`,
+    },
+    [Mail.Variant.AccountRecovery]: {
+      subject: '{serverName} - Récupération de compte',
+      content: `
+Bonjour {name},
+
+Pour réinitialiser votre mot de passe sur {serverName}, veuillez cliquer sur le lien suivant :
+{link}
+
+Vous pouvez également utiliser le code suivant : {otp}
+
+Ce lien et ce code sont valables {ttl} minutes.
+
+{serverName}
+`,
+    },
+    [Mail.Variant.ChangeMail]: {
+      subject: '{serverName} - Changement d\'adresse email',
+      content: `
+Bonjour {name},
+
+Pour changer votre adresse email sur {serverName}, veuillez utiliser le code suivant :
+{otp}
+
+Ce code est valable {ttl} minutes.
+
+{serverName}
+`,
+    },
+  },
 } satisfies GlobalI18n

--- a/src/pages/admin/beatmaps.vue
+++ b/src/pages/admin/beatmaps.vue
@@ -84,6 +84,19 @@ zh-CN:
   md5: 哈希
   status: 状态
   requested-by-player: 玩家投票数
+
+fr-FR:
+  mode: Mode
+  search-text: ID de set, ID de beatmap, artiste, titre, version, hash
+  search: Rechercher
+  sid: ID du set
+  artist: Artiste
+  song: Titre
+  bid: ID de la beatmap
+  version: Version
+  md5: Hash
+  status: Statut
+  requested-by-player: Votes des joueurs
 </i18n>
 
 <template>

--- a/src/pages/clan/[id].vue
+++ b/src/pages/clan/[id].vue
@@ -120,6 +120,13 @@ de-DE:
   member: Mitglied
   members: Mitglieder
   clan-best-scores: Beste Ergebnisse
+
+fr-FR:
+  owner: Chef
+  created-at: Fondé le
+  member: Membre
+  members: Membres
+  clan-best-scores: Meilleurs scores
 </i18n>
 
 <template>

--- a/src/pages/dan/compose.vue
+++ b/src/pages/dan/compose.vue
@@ -150,6 +150,9 @@ en-GB:
 
 zh-CN:
   delete-confirm: 确定删除? 本操作无法撤销。
+
+fr-FR:
+  delete-confirm: Êtes-vous sûr ? Cette action est irréversible.
 </i18n>
 
 <template>

--- a/src/pages/dan/course/detail/[id]/edit.vue
+++ b/src/pages/dan/course/detail/[id]/edit.vue
@@ -149,7 +149,29 @@ zh-CN:
   dangling-only: 仅显示未入池
   delete-dans: 删除池中的段位
 
-# TODO fr, DE
+fr-FR:
+  search-text: Rechercher des dans...
+  search: Rechercher
+  dan: Dan
+  delete: Supprimer
+  confirm-delete: Voulez-vous vraiment supprimer ce cours ?
+  cancel: Annuler
+  save: Enregistrer
+  name: Nom
+  add-dan: Ajouter un Dan
+  remove-dan: Retirer le Dan
+  no-dans: Aucun Dan trouvé
+  actions: Actions
+  description: Description
+  requirements: Conditions
+  full-name: Nom complet (FQDN)
+  create: Créer un cours
+  back: Retour
+  mode: Mode
+  unset: Non défini
+  treat-no-ruleset-cond-as-standard: Traiter l'absence de règle comme standard
+  dangling-only: Non assignés uniquement
+  delete-dans: Supprimer les Dans du cours
 </i18n>
 
 <template>

--- a/src/pages/dan/course/detail/[id]/index.vue
+++ b/src/pages/dan/course/detail/[id]/index.vue
@@ -45,7 +45,18 @@ zh-CN:
   updater: 更新者
   back-to-courses: 返回段位池列表
 
-# TODO fr, DE
+fr-FR:
+  collection: Cours
+  full-name: Nom complet (FQDN)
+  description: Description
+  requirements: Conditions
+  dan: Dan
+  edit: Modifier
+  created-at: Créé le
+  updated-at: Mis à jour le
+  creator: Créateur
+  updater: Éditeur
+  back-to-courses: Retour aux cours
 </i18n>
 
 <template>

--- a/src/pages/dan/course/index.vue
+++ b/src/pages/dan/course/index.vue
@@ -80,6 +80,21 @@ zh-CN:
   requirements: 要求
   dan: 段位
 
+fr-FR:
+  search-text: Rechercher des cours...
+  search: Rechercher
+  detail: Détail
+  mode: Mode
+  ruleset: Règle
+  unset: Non défini
+  treat-no-ruleset-cond-as-standard: traiter les Dans sans exigence de règle comme standard
+  key: Nombre de touches
+  collection: Cours
+  full-name: Nom complet (FQDN)
+  description: Description
+  requirements: Conditions
+  dan: Dan
+
 # TODO fr, DE
 </i18n>
 

--- a/src/pages/dan/course/manage.vue
+++ b/src/pages/dan/course/manage.vue
@@ -104,7 +104,24 @@ zh-CN:
   created-at: 创建时间
   updated-at: 更新时间
   actions: 操作
-# TODO fr, DE
+
+fr-FR:
+  search-text: Rechercher des cours...
+  search: Rechercher
+  collection: Cours
+  dan-count: Nombre de Dans
+  edit: Modifier
+  mode: '@:global.mode'
+  ruleset: '@:global.ruleset'
+  key: Touches
+  treat-no-ruleset-cond-as-standard: Traiter l'absence de règle comme standard
+  unset: Non défini
+  create: Créer
+  creator: Créateur
+  updater: Éditeur
+  created-at: Créé le
+  updated-at: Mis à jour le
+  actions: Actions
 </i18n>
 
 <template>

--- a/src/pages/dan/course/new.vue
+++ b/src/pages/dan/course/new.vue
@@ -58,6 +58,10 @@ en-GB:
 zh-CN:
   create-course: 创建段位池
   back: 返回
+
+fr-FR:
+  create-course: Créer un cours
+  back: Retour
 </i18n>
 
 <template>

--- a/src/pages/dan/detail/[id].vue
+++ b/src/pages/dan/detail/[id].vue
@@ -134,7 +134,20 @@ zh-CN:
     accuracy: 最高ACC
     pp: 最高PP
 
-# TODO fr, DE
+fr-FR:
+  qf-scores: Scores qualifiés
+  load-qualified-scores: Charger les scores qualifiés
+  mode: Mode...
+  ruleset: Règle...
+  unset: Non défini
+  treat-no-ruleset-cond-as-standard: traiter les Dans sans exigence de règle comme standard
+  dedupe-with: Dédupliquer par
+  dedupe:
+    no: Aucune
+    id: Premier qualifié
+    score: Meilleur score
+    accuracy: Meilleure précision
+    pp: Meilleur pp
 </i18n>
 
 <template>

--- a/src/pages/dan/list.vue
+++ b/src/pages/dan/list.vue
@@ -70,6 +70,16 @@ zh-CN:
   treat-no-ruleset-cond-as-standard: 将无玩法要求的段位视为std段位
   key: 键数
 
+fr-FR:
+  search-text: Rechercher des Dans...
+  search: Rechercher
+  detail: Détail
+  mode: Mode...
+  ruleset: Règle...
+  unset: Non défini
+  treat-no-ruleset-cond-as-standard: traiter les Dans sans exigence de règle comme standard
+  key: Nombre de touches
+
 # TODO fr, DE
 </i18n>
 

--- a/src/pages/dan/player.vue
+++ b/src/pages/dan/player.vue
@@ -97,6 +97,14 @@ zh-CN:
   unset: 未指定
   treat-no-ruleset-cond-as-standard: 将无玩法要求的段位视为std端位
   key: 键数
+
+fr-FR:
+  qf-scores: Scores qualifiés (Top 10)
+  load-qualified-scores: Charger les scores qualifiés
+  mode: Mode...
+  ruleset: Règle...
+  unset: Non défini
+  key: Touches
 </i18n>
 
 <template>

--- a/src/server/backend/$base/locales/fr-FR.ts
+++ b/src/server/backend/$base/locales/fr-FR.ts
@@ -1,5 +1,5 @@
 export default {
   landing: {
-    content: 'Nous créons un serveur privé osu! avec des fonctionnalités pour tous les modes. Vous trouverez des algorithmes Relax et Autopilot avancés pour le calcul des pp. Vous pouvez également changer de pseudo comme bon vous semble.',
+    content: 'Un serveur privé osu! pour tous les modes, avec algorithmes RX/AP, calcul des pp, classement général et changements de pseudo illimités.',
   },
 } as const

--- a/src/server/backend/bancho.py/locales/fr-FR.ts
+++ b/src/server/backend/bancho.py/locales/fr-FR.ts
@@ -3,9 +3,9 @@ import type { GlobalI18n } from '~/locales/@types'
 
 export default {
   landing: {
-    content: `Nous créons un serveur privé osu! avec des fonctionnalités pour tous les modes. Vous trouverez des algorithmes Relax et Autopilot avancés pour le calcul des pp. Vous pouvez également changer de pseudo comme bon vous semble.
-- pour plus d'informations，veuillez visiter gulag et la page GitHub de Guccho。
-- notre projet est open source!`,
+    content: `Un serveur privé osu! pour tous les modes, avec algorithmes RX/AP, calcul des pp, classement général et changements de pseudo illimités.
+- Plus d'infos : dépôts GitHub de gulag et Guccho.
+- Projet entièrement open source.`,
   },
   service: {
   },

--- a/src/server/backend/ppy.sb@bancho.py/locales/fr-FR.ts
+++ b/src/server/backend/ppy.sb@bancho.py/locales/fr-FR.ts
@@ -2,8 +2,8 @@ import type { ServerLocale } from './@types'
 
 export default {
   landing: {
-    // TODO update fr tranlsate
-    content: `Bienvenue sur {title} ，un serveur privé osu! complet. Nous disposons d'algorithmes Relax et Autopilot avancés, tout en calculant les pp pour tous les modes.
-Nous avons un classement général et vous pouvez également changer de pseudo comme bon vous semble.`,
+    content: `Bienvenue sur {title}, un serveur privé osu! pour tous les modes, avec algorithmes RX/AP et calcul des pp.
+Rejoignez notre groupe QQ ou Discord (lien en bas à droite) pour échanger avec les autres joueurs.
+Classement général et changements de pseudo illimités.`,
   },
 } satisfies ServerLocale


### PR DESCRIPTION
## Summary
- Filled in previously-stubbed fr-FR sections in the base locale (mode, ruleset, footer, server, beatmap status, errors, mail templates, dan) and fixed two mistranslated strings (`played-at`, `users`) found via zh-CN cross-check
- Cleaned up stray CJK punctuation and stale wording in the French backend landing blurbs
- Added missing fr-FR translations to 17 component-scoped `<i18n>` blocks (Dan feature pages/components, admin beatmaps, clan page) that previously fell back to English

## Test plan
- [ ] `pnpm lint` passes on touched files
- [ ] Switch locale to French in a running dev server and spot-check the Dan pages, admin beatmaps, and clan pages